### PR TITLE
Try to reduce contention between readers & writer in NodeDB

### DIFF
--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -24,7 +24,7 @@ func NewImmutableTree(db dbm.DB, cacheSize int) *ImmutableTree {
 	}
 	return &ImmutableTree{
 		// NodeDB-backed Tree.
-		ndb: newNodeDB(db, cacheSize),
+		ndb: newNodeDB(db, cacheSize, nil),
 	}
 }
 

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -12,7 +12,7 @@ import (
 // Note that this tree is not thread-safe.
 type ImmutableTree struct {
 	root    *Node
-	ndb     *nodeDB
+	ndb     NodeDB
 	version int64
 }
 
@@ -22,9 +22,14 @@ func NewImmutableTree(db dbm.DB, cacheSize int) *ImmutableTree {
 		// In-memory Tree.
 		return &ImmutableTree{}
 	}
+	// NodeDB-backed Tree.
+	return NewImmutableTreeWithNodeDB(NewNodeDB(db, cacheSize, nil))
+}
+
+// NewImmutableTreeWithNodeDB creates an instance that's persisted to the given NodeDB
+func NewImmutableTreeWithNodeDB(ndb NodeDB) *ImmutableTree {
 	return &ImmutableTree{
-		// NodeDB-backed Tree.
-		ndb: newNodeDB(db, cacheSize, nil),
+		ndb: ndb,
 	}
 }
 

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -17,30 +17,17 @@ type MutableTree struct {
 	lastSaved      *ImmutableTree   // The most recently saved tree.
 	orphans        map[string]int64 // Nodes removed by changes to working tree.
 	versions       map[int64]bool   // The previous, saved versions of the tree.
-	ndb            *nodeDB
+	ndb            NodeDB
 }
 
 // NewMutableTree returns a new tree with the specified cache size and datastore.
 func NewMutableTree(db dbm.DB, cacheSize int) *MutableTree {
-	ndb := newNodeDB(db, cacheSize, nil)
-	head := &ImmutableTree{ndb: ndb}
-
-	return &MutableTree{
-		ImmutableTree: head,
-		lastSaved:     head.clone(),
-		orphans:       map[string]int64{},
-		versions:      map[int64]bool{},
-		ndb:           ndb,
-	}
+	ndb := NewNodeDB(db, cacheSize, nil)
+	return NewMutableTreeWithNodeDB(ndb)
 }
 
-// NewMutableTreeWithExternalValueStore returns a new tree with the specified cache size,
-// datastore, and a callback for retrieving leaf values from an external store.
-func NewMutableTreeWithExternalValueStore(
-	db dbm.DB, cacheSize int,
-	getKeyValueCb func(key []byte) []byte,
-) *MutableTree {
-	ndb := newNodeDB(db, cacheSize, getKeyValueCb)
+// NewMutableTreeWithNodeDB returns a new tree with the specified NodeDB.
+func NewMutableTreeWithNodeDB(ndb NodeDB) *MutableTree {
 	head := &ImmutableTree{ndb: ndb}
 
 	return &MutableTree{

--- a/nodedb2.go
+++ b/nodedb2.go
@@ -7,74 +7,36 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/tendermint/tendermint/crypto/tmhash"
 	dbm "github.com/tendermint/tendermint/libs/db"
 )
 
-const (
-	int64Size = 8
-	hashSize  = tmhash.Size
-)
-
-var (
-	// All node keys are prefixed with the byte 'n'. This ensures no collision is
-	// possible with the other keys, and makes them easier to traverse. They are indexed by the node hash.
-	nodeKeyFormat = NewKeyFormat('n', hashSize) // n<hash>
-
-	// Orphans are keyed in the database by their expected lifetime.
-	// The first number represents the *last* version at which the orphan needs
-	// to exist, while the second number represents the *earliest* version at
-	// which it is expected to exist - which starts out by being the version
-	// of the node being orphaned.
-	orphanKeyFormat = NewKeyFormat('o', int64Size, int64Size, hashSize) // o<last-version><first-version><hash>
-
-	// Root nodes are indexed separately by their version
-	rootKeyFormat = NewKeyFormat('r', int64Size) // r<version>
-)
-
-// NodeDB is used by MutableTree & ImmutableTree to persist & load nodes to a DB
-type NodeDB interface {
-	GetNode(hash []byte) *Node
-	SaveNode(node *Node)
-	Has(hash []byte) bool
-	SaveBranch(node *Node) []byte
-	DeleteVersion(version int64, checkLatestVersion bool)
-	SaveOrphans(version int64, orphans map[string]int64)
-	SaveRoot(root *Node, version int64) error
-	SaveEmptyRoot(version int64) error
-	Commit()
-	String() string
-
-	getRoot(version int64) []byte
-	getRoots() (map[int64][]byte, error)
-	getLatestVersion() int64
-	resetLatestVersion(version int64)
-
-	// Only for tests
-	roots() map[int64][]byte
-	leafNodes() []*Node
-	nodes() []*Node
-	orphans() [][]byte
-	size() int
-	traverseOrphans(fn func(k, v []byte))
-}
-
-type nodeDB struct {
-	mtx   sync.Mutex // Read/write lock.
-	db    dbm.DB     // Persistent node storage.
-	batch dbm.Batch  // Batched writing buffer.
+// This NodeDB implementations tries to reduce contention between readers & a single writer.
+//
+// nodeDB has a single mutex that had to be acquired by a reader/writer before they can access
+// either the node cache or the underlying DB. nodeDB2 adds a second mutex to synchronize access to
+// the node cache, while the original mutex is now only used to synchronize write access to the
+// underlying DB batch.
+//
+// Multiple readers may now access the underlying DB concurrently, which means the underlying DB
+// must support concurrent readers (both GoLevelDB and CLevelDB support this).
+type nodeDB2 struct {
+	db       dbm.DB     // Persistent node storage.
+	batchMtx sync.Mutex // Read/write lock to protect the batch.
+	batch    dbm.Batch  // Batched writing buffer.
 
 	latestVersion  int64
+	nodeCacheMtx   sync.Mutex               // Read/write lock to protect the node cache.
 	nodeCache      map[string]*list.Element // Node cache.
 	nodeCacheSize  int                      // Node cache size limit in elements.
 	nodeCacheQueue *list.List               // LRU queue of cache elements. Used for deletion.
 	getLeafValueCb func(key []byte) []byte  // Optional callback to get values stored in leaf nodes.
 }
 
-var _ NodeDB = (*nodeDB)(nil)
+var _ NodeDB = (*nodeDB2)(nil)
 
-func NewNodeDB(db dbm.DB, cacheSize int, getLeafValueCb func(key []byte) []byte) NodeDB {
-	ndb := &nodeDB{
+// NewNodeDB2 returns a new instance
+func NewNodeDB2(db dbm.DB, cacheSize int, getLeafValueCb func(key []byte) []byte) NodeDB {
+	ndb := &nodeDB2{
 		db:             db,
 		batch:          db.NewBatch(),
 		latestVersion:  0, // initially invalid
@@ -88,19 +50,15 @@ func NewNodeDB(db dbm.DB, cacheSize int, getLeafValueCb func(key []byte) []byte)
 
 // GetNode gets a node from cache or disk. If it is an inner node, it does not
 // load its children.
-func (ndb *nodeDB) GetNode(hash []byte) *Node {
-	ndb.mtx.Lock()
-	defer ndb.mtx.Unlock()
-
+func (ndb *nodeDB2) GetNode(hash []byte) *Node {
 	if len(hash) == 0 {
 		panic("nodeDB.GetNode() requires hash")
 	}
 
 	// Check the cache.
-	if elem, ok := ndb.nodeCache[string(hash)]; ok {
-		// Already exists. Move to back of nodeCacheQueue.
-		ndb.nodeCacheQueue.MoveToBack(elem)
-		return elem.Value.(*Node)
+	node := ndb.getCachedNode(hash)
+	if node != nil {
+		return node
 	}
 
 	// Doesn't exist, load.
@@ -122,10 +80,7 @@ func (ndb *nodeDB) GetNode(hash []byte) *Node {
 }
 
 // SaveNode saves a node to disk.
-func (ndb *nodeDB) SaveNode(node *Node) {
-	ndb.mtx.Lock()
-	defer ndb.mtx.Unlock()
-
+func (ndb *nodeDB2) SaveNode(node *Node) {
 	if node.hash == nil {
 		panic("Expected to find node.hash, but none found.")
 	}
@@ -133,20 +88,28 @@ func (ndb *nodeDB) SaveNode(node *Node) {
 		panic("Shouldn't be calling save on an already persisted node.")
 	}
 
+	ndb.writeNode(node)
+	ndb.cacheNode(node)
+}
+
+func (ndb *nodeDB2) writeNode(node *Node) {
+	ndb.batchMtx.Lock()
+	defer ndb.batchMtx.Unlock()
+
 	// Save node bytes to db.
 	buf := new(bytes.Buffer)
 	if err := node.writeBytes(buf, ndb.getLeafValueCb == nil); err != nil {
 		panic(err)
 	}
+
 	ndb.batch.Set(ndb.nodeKey(node.hash), buf.Bytes())
 	debug("BATCH SAVE %X %p\n", node.hash, node)
 
 	node.persisted = true
-	ndb.cacheNode(node)
 }
 
 // Has checks if a hash exists in the database.
-func (ndb *nodeDB) Has(hash []byte) bool {
+func (ndb *nodeDB2) Has(hash []byte) bool {
 	key := ndb.nodeKey(hash)
 
 	if ldb, ok := ndb.db.(*dbm.GoLevelDB); ok {
@@ -163,7 +126,7 @@ func (ndb *nodeDB) Has(hash []byte) bool {
 // NOTE: This function clears leftNode/rigthNode recursively and
 // calls _hash() on the given node.
 // TODO refactor, maybe use hashWithCount() but provide a callback.
-func (ndb *nodeDB) SaveBranch(node *Node) []byte {
+func (ndb *nodeDB2) SaveBranch(node *Node) []byte {
 	if node.persisted {
 		return node.hash
 	}
@@ -185,9 +148,9 @@ func (ndb *nodeDB) SaveBranch(node *Node) []byte {
 }
 
 // DeleteVersion deletes a tree version from disk.
-func (ndb *nodeDB) DeleteVersion(version int64, checkLatestVersion bool) {
-	ndb.mtx.Lock()
-	defer ndb.mtx.Unlock()
+func (ndb *nodeDB2) DeleteVersion(version int64, checkLatestVersion bool) {
+	ndb.batchMtx.Lock()
+	defer ndb.batchMtx.Unlock()
 
 	ndb.deleteOrphans(version)
 	ndb.deleteRoot(version, checkLatestVersion)
@@ -196,9 +159,9 @@ func (ndb *nodeDB) DeleteVersion(version int64, checkLatestVersion bool) {
 // Saves orphaned nodes to disk under a special prefix.
 // version: the new version being saved.
 // orphans: the orphan nodes created since version-1
-func (ndb *nodeDB) SaveOrphans(version int64, orphans map[string]int64) {
-	ndb.mtx.Lock()
-	defer ndb.mtx.Unlock()
+func (ndb *nodeDB2) SaveOrphans(version int64, orphans map[string]int64) {
+	ndb.batchMtx.Lock()
+	defer ndb.batchMtx.Unlock()
 
 	toVersion := ndb.getPreviousVersion(version)
 	for hash, fromVersion := range orphans {
@@ -208,7 +171,7 @@ func (ndb *nodeDB) SaveOrphans(version int64, orphans map[string]int64) {
 }
 
 // Saves a single orphan to disk.
-func (ndb *nodeDB) saveOrphan(hash []byte, fromVersion, toVersion int64) {
+func (ndb *nodeDB2) saveOrphan(hash []byte, fromVersion, toVersion int64) {
 	if fromVersion > toVersion {
 		panic(fmt.Sprintf("Orphan expires before it comes alive.  %d > %d", fromVersion, toVersion))
 	}
@@ -218,7 +181,7 @@ func (ndb *nodeDB) saveOrphan(hash []byte, fromVersion, toVersion int64) {
 
 // deleteOrphans deletes orphaned nodes from disk, and the associated orphan
 // entries.
-func (ndb *nodeDB) deleteOrphans(version int64) {
+func (ndb *nodeDB2) deleteOrphans(version int64) {
 	// Will be zero if there is no previous version.
 	predecessor := ndb.getPreviousVersion(version)
 
@@ -250,36 +213,36 @@ func (ndb *nodeDB) deleteOrphans(version int64) {
 	})
 }
 
-func (ndb *nodeDB) nodeKey(hash []byte) []byte {
+func (ndb *nodeDB2) nodeKey(hash []byte) []byte {
 	return nodeKeyFormat.KeyBytes(hash)
 }
 
-func (ndb *nodeDB) orphanKey(fromVersion, toVersion int64, hash []byte) []byte {
+func (ndb *nodeDB2) orphanKey(fromVersion, toVersion int64, hash []byte) []byte {
 	return orphanKeyFormat.Key(toVersion, fromVersion, hash)
 }
 
-func (ndb *nodeDB) rootKey(version int64) []byte {
+func (ndb *nodeDB2) rootKey(version int64) []byte {
 	return rootKeyFormat.Key(version)
 }
 
-func (ndb *nodeDB) getLatestVersion() int64 {
+func (ndb *nodeDB2) getLatestVersion() int64 {
 	if ndb.latestVersion == 0 {
 		ndb.latestVersion = ndb.getPreviousVersion(1<<63 - 1)
 	}
 	return ndb.latestVersion
 }
 
-func (ndb *nodeDB) updateLatestVersion(version int64) {
+func (ndb *nodeDB2) updateLatestVersion(version int64) {
 	if ndb.latestVersion < version {
 		ndb.latestVersion = version
 	}
 }
 
-func (ndb *nodeDB) resetLatestVersion(version int64) {
+func (ndb *nodeDB2) resetLatestVersion(version int64) {
 	ndb.latestVersion = version
 }
 
-func (ndb *nodeDB) getPreviousVersion(version int64) int64 {
+func (ndb *nodeDB2) getPreviousVersion(version int64) int64 {
 	itr := ndb.db.ReverseIterator(
 		rootKeyFormat.Key(1),
 		rootKeyFormat.Key(version),
@@ -297,7 +260,7 @@ func (ndb *nodeDB) getPreviousVersion(version int64) int64 {
 }
 
 // deleteRoot deletes the root entry from disk, but not the node it points to.
-func (ndb *nodeDB) deleteRoot(version int64, checkLatestVersion bool) {
+func (ndb *nodeDB2) deleteRoot(version int64, checkLatestVersion bool) {
 	if checkLatestVersion && version == ndb.getLatestVersion() {
 		panic("Tried to delete latest version")
 	}
@@ -306,17 +269,17 @@ func (ndb *nodeDB) deleteRoot(version int64, checkLatestVersion bool) {
 	ndb.batch.Delete(key)
 }
 
-func (ndb *nodeDB) traverseOrphans(fn func(k, v []byte)) {
+func (ndb *nodeDB2) traverseOrphans(fn func(k, v []byte)) {
 	ndb.traversePrefix(orphanKeyFormat.Key(), fn)
 }
 
 // Traverse orphans ending at a certain version.
-func (ndb *nodeDB) traverseOrphansVersion(version int64, fn func(k, v []byte)) {
+func (ndb *nodeDB2) traverseOrphansVersion(version int64, fn func(k, v []byte)) {
 	ndb.traversePrefix(orphanKeyFormat.Key(version), fn)
 }
 
 // Traverse all keys.
-func (ndb *nodeDB) traverse(fn func(key, value []byte)) {
+func (ndb *nodeDB2) traverse(fn func(key, value []byte)) {
 	itr := ndb.db.Iterator(nil, nil)
 	defer itr.Close()
 
@@ -326,7 +289,7 @@ func (ndb *nodeDB) traverse(fn func(key, value []byte)) {
 }
 
 // Traverse all keys with a certain prefix.
-func (ndb *nodeDB) traversePrefix(prefix []byte, fn func(k, v []byte)) {
+func (ndb *nodeDB2) traversePrefix(prefix []byte, fn func(k, v []byte)) {
 	itr := dbm.IteratePrefix(ndb.db, prefix)
 	defer itr.Close()
 
@@ -335,7 +298,23 @@ func (ndb *nodeDB) traversePrefix(prefix []byte, fn func(k, v []byte)) {
 	}
 }
 
-func (ndb *nodeDB) uncacheNode(hash []byte) {
+func (ndb *nodeDB2) getCachedNode(hash []byte) *Node {
+	ndb.nodeCacheMtx.Lock()
+	defer ndb.nodeCacheMtx.Unlock()
+
+	if elem, ok := ndb.nodeCache[string(hash)]; ok {
+		// Already exists. Move to back of nodeCacheQueue.
+		ndb.nodeCacheQueue.MoveToBack(elem)
+		return elem.Value.(*Node)
+	}
+
+	return nil
+}
+
+func (ndb *nodeDB2) uncacheNode(hash []byte) {
+	ndb.nodeCacheMtx.Lock()
+	defer ndb.nodeCacheMtx.Unlock()
+
 	if elem, ok := ndb.nodeCache[string(hash)]; ok {
 		ndb.nodeCacheQueue.Remove(elem)
 		delete(ndb.nodeCache, string(hash))
@@ -344,7 +323,10 @@ func (ndb *nodeDB) uncacheNode(hash []byte) {
 
 // Add a node to the cache and pop the least recently used node if we've
 // reached the cache size limit.
-func (ndb *nodeDB) cacheNode(node *Node) {
+func (ndb *nodeDB2) cacheNode(node *Node) {
+	ndb.nodeCacheMtx.Lock()
+	defer ndb.nodeCacheMtx.Unlock()
+
 	elem := ndb.nodeCacheQueue.PushBack(node)
 	ndb.nodeCache[string(node.hash)] = elem
 
@@ -356,19 +338,19 @@ func (ndb *nodeDB) cacheNode(node *Node) {
 }
 
 // Write to disk.
-func (ndb *nodeDB) Commit() {
-	ndb.mtx.Lock()
-	defer ndb.mtx.Unlock()
+func (ndb *nodeDB2) Commit() {
+	ndb.batchMtx.Lock()
+	defer ndb.batchMtx.Unlock()
 
 	ndb.batch.Write()
 	ndb.batch = ndb.db.NewBatch()
 }
 
-func (ndb *nodeDB) getRoot(version int64) []byte {
+func (ndb *nodeDB2) getRoot(version int64) []byte {
 	return ndb.db.Get(ndb.rootKey(version))
 }
 
-func (ndb *nodeDB) getRoots() (map[int64][]byte, error) {
+func (ndb *nodeDB2) getRoots() (map[int64][]byte, error) {
 	roots := map[int64][]byte{}
 
 	ndb.traversePrefix(rootKeyFormat.Key(), func(k, v []byte) {
@@ -381,7 +363,7 @@ func (ndb *nodeDB) getRoots() (map[int64][]byte, error) {
 
 // SaveRoot creates an entry on disk for the given root, so that it can be
 // loaded later.
-func (ndb *nodeDB) SaveRoot(root *Node, version int64) error {
+func (ndb *nodeDB2) SaveRoot(root *Node, version int64) error {
 	if len(root.hash) == 0 {
 		panic("Hash should not be empty")
 	}
@@ -389,13 +371,13 @@ func (ndb *nodeDB) SaveRoot(root *Node, version int64) error {
 }
 
 // SaveEmptyRoot creates an entry on disk for an empty root.
-func (ndb *nodeDB) SaveEmptyRoot(version int64) error {
+func (ndb *nodeDB2) SaveEmptyRoot(version int64) error {
 	return ndb.saveRoot([]byte{}, version)
 }
 
-func (ndb *nodeDB) saveRoot(hash []byte, version int64) error {
-	ndb.mtx.Lock()
-	defer ndb.mtx.Unlock()
+func (ndb *nodeDB2) saveRoot(hash []byte, version int64) error {
+	ndb.batchMtx.Lock()
+	defer ndb.batchMtx.Unlock()
 
 	if version != ndb.getLatestVersion()+1 {
 		return fmt.Errorf("Must save consecutive versions. Expected %d, got %d", ndb.getLatestVersion()+1, version)
@@ -410,7 +392,7 @@ func (ndb *nodeDB) saveRoot(hash []byte, version int64) error {
 
 ////////////////// Utility and test functions /////////////////////////////////
 
-func (ndb *nodeDB) leafNodes() []*Node {
+func (ndb *nodeDB2) leafNodes() []*Node {
 	leaves := []*Node{}
 
 	ndb.traverseNodes(func(hash []byte, node *Node) {
@@ -421,7 +403,7 @@ func (ndb *nodeDB) leafNodes() []*Node {
 	return leaves
 }
 
-func (ndb *nodeDB) nodes() []*Node {
+func (ndb *nodeDB2) nodes() []*Node {
 	nodes := []*Node{}
 
 	ndb.traverseNodes(func(hash []byte, node *Node) {
@@ -430,7 +412,7 @@ func (ndb *nodeDB) nodes() []*Node {
 	return nodes
 }
 
-func (ndb *nodeDB) orphans() [][]byte {
+func (ndb *nodeDB2) orphans() [][]byte {
 	orphans := [][]byte{}
 
 	ndb.traverseOrphans(func(k, v []byte) {
@@ -439,7 +421,7 @@ func (ndb *nodeDB) orphans() [][]byte {
 	return orphans
 }
 
-func (ndb *nodeDB) roots() map[int64][]byte {
+func (ndb *nodeDB2) roots() map[int64][]byte {
 	roots, _ := ndb.getRoots()
 	return roots
 }
@@ -447,7 +429,7 @@ func (ndb *nodeDB) roots() map[int64][]byte {
 // Not efficient.
 // NOTE: DB cannot implement Size() because
 // mutations are not always synchronous.
-func (ndb *nodeDB) size() int {
+func (ndb *nodeDB2) size() int {
 	size := 0
 	ndb.traverse(func(k, v []byte) {
 		size++
@@ -455,7 +437,7 @@ func (ndb *nodeDB) size() int {
 	return size
 }
 
-func (ndb *nodeDB) traverseNodes(fn func(hash []byte, node *Node)) {
+func (ndb *nodeDB2) traverseNodes(fn func(hash []byte, node *Node)) {
 	nodes := []*Node{}
 
 	ndb.traversePrefix(nodeKeyFormat.Key(), func(key, value []byte) {
@@ -476,7 +458,7 @@ func (ndb *nodeDB) traverseNodes(fn func(hash []byte, node *Node)) {
 	}
 }
 
-func (ndb *nodeDB) String() string {
+func (ndb *nodeDB2) String() string {
 	var str string
 	index := 0
 

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -14,8 +14,24 @@ func BenchmarkNodeKey(b *testing.B) {
 	}
 }
 
+func BenchmarkNodeKey2(b *testing.B) {
+	ndb := &nodeDB2{}
+	hashes := makeHashes(b, 2432325)
+	for i := 0; i < b.N; i++ {
+		ndb.nodeKey(hashes[i])
+	}
+}
+
 func BenchmarkOrphanKey(b *testing.B) {
 	ndb := &nodeDB{}
+	hashes := makeHashes(b, 2432325)
+	for i := 0; i < b.N; i++ {
+		ndb.orphanKey(1234, 1239, hashes[i])
+	}
+}
+
+func BenchmarkOrphanKey2(b *testing.B) {
+	ndb := &nodeDB2{}
 	hashes := makeHashes(b, 2432325)
 	for i := 0; i < b.N; i++ {
 		ndb.orphanKey(1234, 1239, hashes[i])
@@ -26,7 +42,7 @@ func makeHashes(b *testing.B, seed int64) [][]byte {
 	b.StopTimer()
 	rnd := rand.NewSource(seed)
 	hashes := make([][]byte, b.N)
-	hashBytes := 8*((hashSize+7)/8)
+	hashBytes := 8 * ((hashSize + 7) / 8)
 	for i := 0; i < b.N; i++ {
 		hashes[i] = make([]byte, hashBytes)
 		for b := 0; b < hashBytes; b += 8 {

--- a/util.go
+++ b/util.go
@@ -12,7 +12,7 @@ func PrintTree(tree *ImmutableTree) {
 	printNode(ndb, root, 0)
 }
 
-func printNode(ndb *nodeDB, node *Node, indent int) {
+func printNode(ndb NodeDB, node *Node, indent int) {
 	indentPrefix := ""
 	for i := 0; i < indent; i++ {
 		indentPrefix += "    "


### PR DESCRIPTION
Previously there was a single mutex that had to be acquired by a
reader/writer before they could access either the node cache or the
underlying DB. These changes introduce a second mutex to synchronize
access to the node cache, while the original mutex is now only used to
synchronize write access to the underlying DB.

Multiple readers may now access the underlying DB concurrently, this
should work with GoLevelDB at least since it supports concurrent readers.