### PR TITLE
Add NewMutableTreeWithVersion() function to create MutableTree instances

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -36,6 +36,18 @@ func NewMutableTree(db dbm.DB, cacheSize int) *MutableTree {
 	}
 }
 
+// NewMutableTreeWithVersion returns a new tree with the specified cache size, datastore, and version.
+// If a non-zero version is specified the db must be empty, otherwise the result of saving the tree
+// to the db may be unpredictable!
+func NewMutableTreeWithVersion(db dbm.DB, cacheSize int, version int64) *MutableTree {
+	tree := NewMutableTree(db, cacheSize)
+	if version > 0 {
+		tree.version = version
+		tree.ndb.resetLatestVersion(version)
+	}
+	return tree
+}
+
 // IsEmpty returns whether or not the tree has any keys. Only trees that are
 // not empty can be saved.
 func (tree *MutableTree) IsEmpty() bool {

--- a/tree_fuzz.go
+++ b/tree_fuzz.go
@@ -109,11 +109,11 @@ func (p *Program) ExecuteBlock(tree *MutableTree) error {
 	return nil
 }
 
-func GenerateBlocksHashKeys(numBlocks, blockSize int, prefix []byte) []*Program {
+func GenerateBlocksHashKeys(numBlocks, blockSize int) []*Program {
 	fmt.Println()
 	var history []*Program
 	for i := 0; i < numBlocks; i++ {
-		history = append(history, getRandomBlockHashKeys(blockSize, prefix))
+		history = append(history, getRandomBlockHashKeys(blockSize))
 	}
 	return history
 }
@@ -143,14 +143,14 @@ func getRandomBlock(size int) *Program {
 	return p
 }
 
-func getRandomBlockHashKeys(size int, prefix []byte) *Program {
+func getRandomBlockHashKeys(size int) *Program {
 	p := &Program{}
 
 	for p.size() < size {
 		r, v := []byte(common.RandStr(4)), []byte(common.RandStr(1))
 		hash := sha3.NewLegacyKeccak256()
 		hash.Write(r)
-		key := append(prefix, hash.Sum(nil)...)
+		key := hash.Sum(nil)
 		switch common.RandInt() % 4 {
 		case 0, 1, 2:
 			p.addInstruction(instruction{op: "SET", k: key, v: v})


### PR DESCRIPTION
This is useful when you want to copy a single version of a tree from
one DB to another while retaining the version number of the original
tree.